### PR TITLE
User configurable forecast days + align card bottom to row

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ The 3 different rows, being:
 
 - The current weather icon, the current temperature and title
 - The details about the current weather
-- The 5 day forecast
+- The future forecast, default is 5 days, can be set from 1 to 8 days
 
 ```yaml
 type: custom:weather-card
@@ -73,6 +73,7 @@ entity: weather.yourweatherentity
 current: true
 details: false
 forecast: true
+forecast_days: 5
 ```
 
 If you want to show the sunrise and sunset times, make sure the `sun` component is enabled:

--- a/dist/weather-card-editor.js
+++ b/dist/weather-card-editor.js
@@ -55,6 +55,10 @@ export class WeatherCardEditor extends LitElement {
     return this._config.forecast !== false;
   }
 
+  get _forecast_days() {
+    return this._config.forecast_days;
+  }
+
   render() {
     if (!this.hass) {
       return html``;
@@ -125,6 +129,13 @@ export class WeatherCardEditor extends LitElement {
             .configValue="${"forecast"}"
             @change="${this._valueChanged}"
             >Show forecast</ha-switch
+          >
+          <paper-input
+            label="Forecast Days"
+            .value="${this._forecast_days}"
+            .configValue="${"forecast_days"}"
+            @value-changed="${this._valueChanged}"
+            ></paper-input
           >
         </div>
       </div>

--- a/dist/weather-card.js
+++ b/dist/weather-card.js
@@ -99,6 +99,11 @@ class WeatherCard extends LitElement {
     if (!config.entity) {
       throw new Error("Please define a weather entity");
     }
+    
+    if (config.forecast && config.forecast_days == null) config.forecast_days = 5;
+    if (config.forecast_days <= 1) config.forecast_days = 1;
+    if (config.forecast_days >= 8) config.forecast_days = 8;
+    
     this._config = config;
   }
 
@@ -138,7 +143,7 @@ class WeatherCard extends LitElement {
         ${this._config.current !== false ? this.renderCurrent(stateObj) : ""}
         ${this._config.details !== false ? this.renderDetails(stateObj) : ""}
         ${this._config.forecast !== false
-          ? this.renderForecast(stateObj.attributes.forecast)
+          ? this.renderForecast(stateObj.attributes.forecast, this._config.forecast_days)
           : ""}
       </ha-card>
     `;
@@ -231,7 +236,7 @@ class WeatherCard extends LitElement {
     `;
   }
 
-  renderForecast(forecast) {
+  renderForecast(forecast, forecast_days) {
     if (!forecast || forecast.length === 0) {
       return html``;
     }
@@ -241,7 +246,7 @@ class WeatherCard extends LitElement {
     this.numberElements++;
     return html`
       <div class="forecast clear ${this.numberElements > 1 ? "spacer" : ""}">
-        ${forecast.slice(0, 5).map(
+        ${forecast.slice(0, forecast_days).map(
           daily => html`
             <div class="day">
               <div class="dayname">


### PR DESCRIPTION
User can set the number of days to forecast from the default of 5 days, to 1 to 8 days