### PR TITLE
added options to hourly forecast

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ The 3 different rows, being:
 
 - The current weather icon, the current temperature and title
 - The details about the current weather
-- The 5 day forecast
+- The X day forecast or hourly forecast
 
 ```yaml
 type: custom:weather-card
@@ -73,6 +73,8 @@ entity: weather.yourweatherentity
 current: true
 details: false
 forecast: true
+hourly_forecast: false
+number_of_forecasts: 5
 ```
 
 If you want to show the sunrise and sunset times, make sure the `sun` component is enabled:
@@ -92,4 +94,15 @@ weather:
   - platform: darksky
     api_key: YOUR_API_KEY
     mode: daily
+```
+
+### OpenWeather Map:
+
+When using OpenWeather map you can select hourly(default) or daily forecast to show.
+
+```yaml
+# Example configuration.yaml entry
+weather:
+  - platform: openweathermap
+    api_key: YOUR_API_KEY
 ```

--- a/dist/weather-card-editor.js
+++ b/dist/weather-card-editor.js
@@ -55,6 +55,14 @@ export class WeatherCardEditor extends LitElement {
     return this._config.forecast !== false;
   }
 
+  get _hourly_forecast() {
+    return this._config.hourly_forecast !== false;
+  }
+
+  get _number_of_forecasts() {
+    return this._config.number_of_forecasts || 5;
+  }
+
   render() {
     if (!this.hass) {
       return html``;
@@ -126,6 +134,18 @@ export class WeatherCardEditor extends LitElement {
             @change="${this._valueChanged}"
             >Show forecast</ha-switch
           >
+          <ha-switch
+          .checked=${this._hourly_forecast}
+          .configValue="${"hourly_forecast"}"
+          @change="${this._valueChanged}"
+          >Show hourly forecast</ha-switch
+          >
+          <paper-input
+          label="Number of future forcasts"
+          type="number" min="1" max="8" value=${this._number_of_forecasts}
+          .configValue="${"number_of_forecasts"}"
+          @value-changed="${this._valueChanged}"
+          ></paper-input>
         </div>
       </div>
     `;

--- a/dist/weather-card.js
+++ b/dist/weather-card.js
@@ -241,13 +241,14 @@ class WeatherCard extends LitElement {
     this.numberElements++;
     return html`
       <div class="forecast clear ${this.numberElements > 1 ? "spacer" : ""}">
-        ${forecast.slice(0, 5).map(
-          daily => html`
+      ${forecast.slice(0, this._config.number_of_forecasts ? this._config.number_of_forecasts : 5 ).map(
+        daily => html`
             <div class="day">
               <div class="dayname">
-                ${new Date(daily.datetime).toLocaleDateString(lang, {
-                  weekday: "short"
-                })}
+              ${this._config.hourly_forecast 
+                ? new Date(daily.datetime).toLocaleTimeString(lang, { hour: '2-digit', minute: '2-digit' })
+                : new Date(daily.datetime).toLocaleDateString(lang, {weekday: "short" })
+              }
               </div>
               <i
                 class="icon"


### PR DESCRIPTION
I added option to show hourly forecast instead of future days.
this change is reflected in graphical editor, and also updated documentation with example. 