### PR TITLE
use hass.language for formatting sun rising/setting and reduce precision

### DIFF
--- a/dist/weather-card.js
+++ b/dist/weather-card.js
@@ -127,6 +127,7 @@ class WeatherCard extends LitElement {
 
     this.numberElements = 0;
 
+    const lang = this.hass.selectedLanguage || this.hass.language;
     const stateObj = this.hass.states[this._config.entity];
 
     if (!stateObj) {
@@ -149,9 +150,9 @@ class WeatherCard extends LitElement {
     return html`
       <ha-card @click="${this._handleClick}">
         ${this._config.current !== false ? this.renderCurrent(stateObj) : ""}
-        ${this._config.details !== false ? this.renderDetails(stateObj) : ""}
+        ${this._config.details !== false ? this.renderDetails(stateObj, lang) : ""}
         ${this._config.forecast !== false
-          ? this.renderForecast(stateObj.attributes.forecast)
+          ? this.renderForecast(stateObj.attributes.forecast, lang)
           : ""}
       </ha-card>
     `;
@@ -183,9 +184,8 @@ class WeatherCard extends LitElement {
     `;
   }
 
-  renderDetails(stateObj) {
+  renderDetails(stateObj, lang) {
     const sun = this.hass.states["sun.sun"];
-    const lang = this.hass.selectedLanguage || this.hass.language;
     let next_rising;
     let next_setting;
 
@@ -249,12 +249,10 @@ class WeatherCard extends LitElement {
     `;
   }
 
-  renderForecast(forecast) {
+  renderForecast(forecast, lang) {
     if (!forecast || forecast.length === 0) {
       return html``;
     }
-
-    const lang = this.hass.selectedLanguage || this.hass.language;
 
     this.numberElements++;
     return html`

--- a/dist/weather-card.js
+++ b/dist/weather-card.js
@@ -185,12 +185,19 @@ class WeatherCard extends LitElement {
 
   renderDetails(stateObj) {
     const sun = this.hass.states["sun.sun"];
+    const lang = this.hass.selectedLanguage || this.hass.language;
     let next_rising;
     let next_setting;
 
     if (sun) {
-      next_rising = new Date(sun.attributes.next_rising);
-      next_setting = new Date(sun.attributes.next_setting);
+      next_rising = new Date(sun.attributes.next_rising).toLocaleTimeString(lang, {
+                        hour: "2-digit",
+                        minute: "2-digit",
+                    });
+      next_setting = new Date(sun.attributes.next_setting).toLocaleTimeString(lang, {
+                        hour: "2-digit",
+                        minute: "2-digit",
+                    });
     }
 
     this.numberElements++;
@@ -226,7 +233,7 @@ class WeatherCard extends LitElement {
           ? html`
               <li>
                 <ha-icon icon="mdi:weather-sunset-up"></ha-icon>
-                ${next_rising.toLocaleTimeString()}
+                ${next_rising}
               </li>
             `
           : ""}
@@ -234,7 +241,7 @@ class WeatherCard extends LitElement {
           ? html`
               <li>
                 <ha-icon icon="mdi:weather-sunset-down"></ha-icon>
-                ${next_setting.toLocaleTimeString()}
+                ${next_setting}
               </li>
             `
           : ""}


### PR DESCRIPTION
- use hass.language for formatting sun rising/setting (as used in forecast)
- reduce precision to minutes (should be adequate)