### PR TITLE
Display 'not available' in standard layout

### DIFF
--- a/dist/weather-card.js
+++ b/dist/weather-card.js
@@ -131,18 +131,9 @@ class WeatherCard extends LitElement {
 
     if (!stateObj) {
       return html`
-        <style>
-          .not-found {
-            flex: 1;
-            background-color: yellow;
-            padding: 8px;
-          }
-        </style>
-        <ha-card>
-          <div class="not-found">
+        <hui-warning>
             Entity not available: ${this._config.entity}
-          </div>
-        </ha-card>
+        </hui-warning>
       `;
     }
 


### PR DESCRIPTION
For the time being the error 'not available' is displayed with a yellow background and the standard font colour of the theme. In my case, the theme font colour is white which was not readable any more.

![alt](https://user-images.githubusercontent.com/25910703/103440643-991aee00-4c47-11eb-9858-32c1937087b3.png)

This pull request removes the 'not-found' class and uses the standard home assistant class. New layout is as follows:

![neu](https://user-images.githubusercontent.com/25910703/103440718-4d1c7900-4c48-11eb-8599-7755cc61671e.png)