### PR TITLE
Show wind direction & speed in daily/hourly forecast

### DIFF
--- a/dist/weather-card.js
+++ b/dist/weather-card.js
@@ -311,6 +311,16 @@ class WeatherCard extends LitElement {
                       </div>
                     `
                   : ""}
+
+                  <div class="wind">
+                      <span class="wind-direction-arrow" style="transform: rotate(${parseInt(daily.wind_bearing) + 180}deg)">
+                          <ha-icon icon="mdi:arrow-up-thin"></ha-icon>
+                      </span>
+                      ${daily.wind_speed}<span class="unit">
+                        ${this.getUnit("length")}/h
+                      </span>
+                  </div>
+
               </div>
             `
           )}
@@ -493,7 +503,7 @@ class WeatherCard extends LitElement {
         color: var(--secondary-text-color);
       }
 
-      .precipitation {
+      .wind, .precipitation {
         color: var(--primary-text-color);
         font-weight: 300;
       }
@@ -528,6 +538,10 @@ class WeatherCard extends LitElement {
         left: 6em;
         word-wrap: break-word;
         width: 30%;
+      }
+
+      .wind-direction-arrow {
+        display: inline-block;
       }
     `;
   }

--- a/dist/weather-card.js
+++ b/dist/weather-card.js
@@ -316,8 +316,10 @@ class WeatherCard extends LitElement {
                       <span class="wind-direction-arrow" style="transform: rotate(${daily.wind_bearing}deg)">
                           <ha-icon icon="mdi:arrow-down-thin"></ha-icon>
                       </span>
-                      ${Math.round(daily.wind_speed)}<span class="unit">
-                        ${this.getUnit("length")}/h
+                      <span class="windspeed">
+                          ${Math.round(daily.wind_speed)}<span class="unit">
+                            ${this.getUnit("length")}/h
+                          </span>
                       </span>
                   </div>
 
@@ -538,6 +540,10 @@ class WeatherCard extends LitElement {
         left: 6em;
         word-wrap: break-word;
         width: 30%;
+      }
+
+      .windspeed {
+        white-space: nowrap;
       }
 
       .wind-direction-arrow {

--- a/dist/weather-card.js
+++ b/dist/weather-card.js
@@ -313,10 +313,10 @@ class WeatherCard extends LitElement {
                   : ""}
 
                   <div class="wind">
-                      <span class="wind-direction-arrow" style="transform: rotate(${parseInt(daily.wind_bearing) + 180}deg)">
-                          <ha-icon icon="mdi:arrow-up-thin"></ha-icon>
+                      <span class="wind-direction-arrow" style="transform: rotate(${daily.wind_bearing}deg)">
+                          <ha-icon icon="mdi:arrow-down-thin"></ha-icon>
                       </span>
-                      ${daily.wind_speed}<span class="unit">
+                      ${Math.round(daily.wind_speed)}<span class="unit">
                         ${this.getUnit("length")}/h
                       </span>
                   </div>


### PR DESCRIPTION
This PR adds wind speed and direction into the hourly/daily forecast.

![image](https://github.com/bramkragten/weather-card/assets/6639960/b63ae663-bdb9-4bfe-898c-aa3bb011a0e0)

It uses a direction arrow rather than compass point notation to save space (although i also find this easier to read).